### PR TITLE
refactor: make Prometheus functionality optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ base64 = "0.22"
 bytes = "1.5"
 chrono = "0.4"
 http = "1.1"
-itertools = "0.13"
-prometheus = "0.13"
+itertools = { version = "0.13", optional = true }
+prometheus = { version = "0.13", optional = true }
 rasn = "0.15"
 rasn-ocsp = "0.15"
 rasn-pkix = "0.15"
@@ -55,6 +55,10 @@ httptest = "0.16"
 
 [lib]
 doctest = false
+
+[features]
+default = ["prometheus"]
+prometheus = ["itertools", "dep:prometheus"]
 
 [build-dependencies]
 readme-rustdocifier = "0.1.0"

--- a/README_DOCS.md
+++ b/README_DOCS.md
@@ -41,7 +41,7 @@ Other notes:
 
 ### Metrics
 
-Stapler supports a few Prometheus metrics - create it using one of `new_..._with_registry()` constructors and provide a Prometheus [`Registry`](prometheus::Registry) reference to register the metrics in.
+Stapler supports a few Prometheus metrics - enable the `prometheus` feature (it is enabled by default), create it using one of `new_..._with_registry()` constructors and provide a Prometheus [`Registry`](prometheus::Registry) reference to register the metrics in.
 
 ### Example
 


### PR DESCRIPTION
I have found that the `prometheus` crate depends on versions of the `pathbuf` crate that are vulnerable to [RUSTSEC-2024-0437](https://rustsec.org/advisories/RUSTSEC-2024-0437.html). To mitigate this risk and reduce software bloat, I propose making the `ocsp-stapler` crate optionally depend on the `prometheus` crate. 

I have added a feature flag for `prometheus`, which is enabled by default to ensure that existing users continue to have access to its functionality without disruption. Users who do not require `prometheus` can disable this feature in their configuration.

This change has been tested to ensure that it does not break existing functionality, and I updated the documentation to reflect this new feature flag.