### PR TITLE
Stop OCSP stapler background task when resolver is dropped

### DIFF
--- a/src/stapler.rs
+++ b/src/stapler.rs
@@ -488,6 +488,11 @@ impl StaplerActor {
                         } else {
                             self.refresh(now).await;
                         }
+                    } else {
+                        // The OCSP stapler struct is dropped, but the task is still running...
+                        // So interrupt the task.
+                        warn!("OCSP-Stapler: stapler dropped, exiting");
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
I have found that when the OCSP stapler background task is running, but the OCSP stapler struct was dropped, the background task is continuously trying to receive the data from a closed channel, leading to a loop causing high CPU usage.

This pull request would make the OCSP stapler background task exit when the OCSP stapler struct is dropped (and an async channel closed).